### PR TITLE
FIXBUILD: drop to 2 deployed instances and update to latest helm chart

### DIFF
--- a/helm_deploy/hmpps-probation-estate-api/Chart.yaml
+++ b/helm_deploy/hmpps-probation-estate-api/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-probation-estate-api
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 1.5.0
+    version: 2.1.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.1.0

--- a/helm_deploy/hmpps-probation-estate-api/values.yaml
+++ b/helm_deploy/hmpps-probation-estate-api/values.yaml
@@ -2,7 +2,7 @@
 generic-service:
   nameOverride: hmpps-probation-estate-api
 
-  replicaCount: 4
+  replicaCount: 2
 
   image:
     repository: quay.io/hmpps/hmpps-probation-estate-api

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,8 +1,6 @@
 ---
 
 generic-service:
-  replicaCount: 2
-
   ingress:
     host: hmpps-probation-estate-api-dev.hmpps.service.justice.gov.uk
 


### PR DESCRIPTION
I cannot find the release notes for the helm charts in the project, so I assume they are fully backwards compatible despite the major version change