### PR TITLE
Wfp 2320 fix spelling error

### DIFF
--- a/src/main/resources/db/migration/V1_41__UPDATE_HFKCW-teams.sql
+++ b/src/main/resources/db/migration/V1_41__UPDATE_HFKCW-teams.sql
@@ -1,0 +1,15 @@
+UPDATE team
+SET name = 'HFKCW1'
+WHERE code = 'N07557';
+UPDATE team
+SET name = 'HFKCW2'
+WHERE code = 'N07556';
+UPDATE team
+SET name = 'HFKCW3'
+WHERE code = 'N07562';
+UPDATE team
+SET name = 'HFKCW4'
+WHERE code = 'N07001';
+UPDATE team
+SET name = 'HFCKW PQiP'
+WHERE code = 'LDNNHAF';

--- a/src/main/resources/db/migration/V1_41__UPDATE_HFKCW-teams.sql
+++ b/src/main/resources/db/migration/V1_41__UPDATE_HFKCW-teams.sql
@@ -12,4 +12,4 @@ SET name = 'HFKCW4'
 WHERE code = 'N07001';
 UPDATE team
 SET name = 'HFCKW PQiP'
-WHERE code = 'LDNNHAF';
+WHERE code = 'N07V10';


### PR DESCRIPTION
So we have teams in our tool that are spelt incorrectly, `HFCKW` instead of `HFKCW`, so this PR just updates them 