### PR TITLE
Remove local NVD cache configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,11 +14,6 @@ configurations {
   testImplementation { exclude(group = "org.junit.vintage") }
 }
 
-dependencyCheck {
-  suppressionFiles.add("suppressions.xml")
-  nvd.datafeedUrl = "file:///opt/vulnz/cache"
-}
-
 dependencies {
 
   implementation("org.springframework.boot:spring-boot-starter-security")


### PR DESCRIPTION
Configuration change required to support the move to Github Pages for the NVD Cache. As per [this conversation](https://mojdt.slack.com/archives/C06MWP0UKDE/p1784300758956369) - the local configuration overrides the OWASP workflow parameter