### PR TITLE
Added "N50CAC", "N50CAW", "N50CHE", "N50MPL", "N50ODM", "N50GQM",

### DIFF
--- a/src/main/resources/config/filtered-team-codes.json
+++ b/src/main/resources/config/filtered-team-codes.json
@@ -1,4 +1,10 @@
 [
+  "N50CAC",
+  "N50CAW",
+  "N50CHE",
+  "N50MPL",
+  "N50ODM",
+  "N50GQM",
   "N07LCK",
   "N50BO1",
   "N5517L",


### PR DESCRIPTION
Team: GM Manchester N1 N50CAC
Region: Manchester North N50
PDU: Manchester North N50MANC
LAU: Manchester North N50MCN

 Team: GM Manchester N2 N50CAW
Region: Manchester North N50
PDU: Manchester North N50MANC
LAU: Manchester North N50MCN

 Team: GM Manchester N3 N50CHE
Region: Manchester North N50
PDU: Manchester North N50MANC
LAU: Manchester North N50MCN

 Team: GM Manchester N4 N50MPL
Region: Manchester North N50
PDU: Manchester North N50MANC
LAU: Manchester North N50MCN

 Team: GM Manchester N5 N50ODM
Region: Manchester North N50
PDU: Manchester North N50MANC
LAU: Manchester North N50MCN

 Team: GM Manchester N6 N50GQM
Region: Manchester North N50
PDU: Manchester North N50MANC
LAU: Manchester North N50MCN